### PR TITLE
Add basic CSS styles for AddTodo form

### DIFF
--- a/src/styles/todo.css
+++ b/src/styles/todo.css
@@ -1,0 +1,50 @@
+/* AddTodo Form Styles */
+.add-todo-form {
+  margin-bottom: 2rem;
+  padding: 1rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+}
+
+.add-todo-input-group {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.add-todo-input {
+  flex: 1;
+  padding: 0.75rem;
+  border: 2px solid #e9ecef;
+  border-radius: 6px;
+  font-size: 1rem;
+  transition: border-color 0.2s ease;
+}
+
+.add-todo-input:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.1);
+}
+
+.add-todo-button {
+  padding: 0.75rem 1.5rem;
+  background: #007bff;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.add-todo-button:hover:not(:disabled) {
+  background: #0056b3;
+}
+
+.add-todo-button:disabled {
+  background: #6c757d;
+  cursor: not-allowed;
+  opacity: 0.6;
+}


### PR DESCRIPTION
- Created src/styles/todo.css with form styling
- Styled add-todo-form with background and padding
- Added flex layout for input group
- Styled input with focus states and transitions
- Styled button with hover and disabled states
- Includes modern design with rounded corners and shadows